### PR TITLE
GitHub Release webhook

### DIFF
--- a/examples/irccat.json
+++ b/examples/irccat.json
@@ -8,9 +8,9 @@
     "tls_key": "",
     "tls_cert": "",
     "listeners": {
-      "grafana": "#channel"
+      "grafana": "#channel",
       "github-releases": {
-	    "irccat": "#irccat-dev"
+	    "irccat": "#irccat-dev",
 	    "go": "#go-nuts"
 	  }
     }

--- a/examples/irccat.json
+++ b/examples/irccat.json
@@ -9,6 +9,10 @@
     "tls_cert": "",
     "listeners": {
       "grafana": "#channel"
+      "github-releases": {
+	    "irccat": "#irccat-dev"
+	    "go": "#go-nuts"
+	  }
     }
   },
   "irc": {

--- a/httplistener/github-releases.go
+++ b/httplistener/github-releases.go
@@ -49,7 +49,7 @@ func (hl *HTTPListener) githubReleasesHandler(w http.ResponseWriter, request *ht
 		msg := fmt.Sprintf("[\x02Release\x0f] \x02%s\x0f version \x02%s\x0f has been published: %s", name, release, payload.Release.Html_url)
 
 		channelKey := fmt.Sprintf("http.listeners.github-releases.%s", payload.Repository.Name)
-		channel := viper.getString(channelKey)
+		channel := viper.GetString(channelKey)
 		log.Infof("%s [%s] GitHub Release", request.RemoteAddr, channel)
 		hl.irc.Privmsgf(channel, msg)
 	}

--- a/httplistener/github-releases.go
+++ b/httplistener/github-releases.go
@@ -1,0 +1,56 @@
+package httplistener
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/viper"
+	"net/http"
+)
+
+type githubRepository struct {
+	Name        string
+	Description string
+}
+
+type githubRelease struct {
+	Html_url    string
+	Tag_name    string
+	Name        string
+}
+
+type githubPayload struct {
+	Action      string
+	Release     githubRelease
+	Repository  githubRepository
+}
+
+func (hl *HTTPListener) githubReleasesHandler(w http.ResponseWriter, request *http.Request) {
+	if request.Method != "POST" {
+		http.NotFound(w, request)
+		return
+	}
+
+	var payload githubPayload
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(request.Body)
+	json.Unmarshal(buf.Bytes(), &payload)
+	
+	if payload.Action == "published" {
+		name := payload.Repository.Description
+		if name == "" {
+			name = payload.Repository.Name
+		}
+		release := payload.Release.Name
+		if release == "" {
+			release = payload.Release.Tag_name
+		}
+		
+		msg := fmt.Sprintf("[\x02Release\x0f] \x02%s\x0f version \x02%s\x0f has been published: %s", name, release, payload.Release.Html_url)
+
+		channelKey := fmt.Sprintf("http.listeners.github-releases.%s", payload.Repository.Name)
+		channel := viper.getString(channelKey)
+		log.Infof("%s [%s] GitHub Release", request.RemoteAddr, channel)
+		hl.irc.Privmsgf(channel, msg)
+	}
+}

--- a/httplistener/httplistener.go
+++ b/httplistener/httplistener.go
@@ -27,6 +27,10 @@ func New(irc *irc.Connection) (*HTTPListener, error) {
 		mux.HandleFunc("/grafana", hl.grafanaAlertHandler)
 	}
 
+	if viper.IsSet("http.listeners.github-releases") {
+		mux.HandleFunc("/github-releases", hl.githubReleasesHandler)
+	}
+
 	hl.http.Handler = mux
 	log.Infof("Listening for HTTP requests on %s", viper.GetString("http.listen"))
 	if viper.GetBool("http.tls") {


### PR DESCRIPTION
Adds a webhook to notify on new GitHub releases. Channels can be set per-repository in the configuration file.