### PR TITLE
nc compatible /send endpoint, DRY-ed dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ IRC formatting is supported (see a full [list of codes](tcplistener/colours.go#L
     echo "Status is%GREEN OK %NORMAL" | nc irccat-host 12345
 
 ## HTTP → IRC
-There's a simple HTTP endpoint for sending messages:
+There's a similar HTTP endpoint for sending messages. You can use curl in lieu
+of netcat, with "-d @-" to read POST data from stdin, like so:
 
-    curl -X POST http://irccat-host:8045/send -d
-        '{"to": "#channel", "body": "Hello world"}'
+    echo "Hello world" | curl -d @- http://irccat-host/send
+
+Everything that works via netcat also works by POST to /send.
 
 There are also endpoints which support app-specific webhooks, currently:
 

--- a/dispatcher/colours.go
+++ b/dispatcher/colours.go
@@ -1,4 +1,4 @@
-package tcplistener
+package dispatcher
 
 import "strings"
 

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -1,0 +1,46 @@
+package dispatcher
+
+import (
+	"github.com/juju/loggo"
+	"github.com/spf13/viper"
+	"github.com/thoj/go-ircevent"
+	"strings"
+)
+
+// Take a string, parse out the recipients, and send to IRC.
+//
+// eg:
+//  hello world                 [goes to default channel]
+//  #test hello world           [goes to #test, if joined]
+//  #test,@alice hello world    [goes to #test and alice]
+//  #* hello world              [goes to all channels bot is in]
+func Send(irc *irc.Connection, msg string, log loggo.Logger, origin string) {
+	channels := viper.GetStringSlice("irc.channels")
+
+	if msg[0] == '#' || msg[0] == '@' {
+		parts := strings.SplitN(msg, " ", 2)
+		if parts[0] == "#*" {
+			for _, channel := range channels {
+				irc.Privmsg(channel, replaceFormatting(parts[1]))
+			}
+		} else {
+			targets := strings.Split(parts[0], ",")
+			for _, target := range targets {
+				if target[0] == '@' {
+					target = target[1:]
+				}
+				irc.Privmsg(target, replaceFormatting(parts[1]))
+			}
+		}
+		log.Infof("from[%s] send[%s] %s", origin, parts[0], parts[1])
+	} else if len(msg) > 7 && msg[0:6] == "%TOPIC" {
+		parts := strings.SplitN(msg, " ", 3)
+		irc.SendRawf("TOPIC %s :%s", parts[1], replaceFormatting(parts[2]))
+		log.Infof("from[%s] topic[%s] %s", origin, parts[1], parts[2])
+	} else {
+		if len(channels) > 0 {
+			irc.Privmsg(channels[0], replaceFormatting(msg))
+			log.Infof("from[%s] send_default[%s] %s", origin, channels[0], msg)
+		}
+	}
+}


### PR DESCRIPTION
* made the /send endpoint accept the same format as tcplistener (no json)
* abstracted the parse+send logic so it's shared between /send and tcplistener
* updated readme accordingly