### PR TITLE
short git hashes are a prefix, not a suffix

### DIFF
--- a/httplistener/templates.go
+++ b/httplistener/templates.go
@@ -39,7 +39,7 @@ func truncateSha(sha string) string {
 	if len(sha) < 8 {
 		return ""
 	}
-	return sha[len(sha)-7:]
+	return sha[:8]
 }
 
 // Colour helper functions to try and declutter


### PR DESCRIPTION
Cherry-picked from my fork which has many more changes. Not tested directly on your master, but I'm pretty confident about this change working cleanly.

Before:
```
16:26Z <PowerGit> [pdns] rgacogne pushed 2 commits to branch master: https://github.com/PowerDNS/pdns/compare/6f47ac4f8c97...ce7fdf89dcbf
16:26Z <PowerGit>  • rgacogne (6415d1b): rec: Fix the cache cleaning code being only run once for workers
16:26Z <PowerGit>  • rgacogne (1c4c58b): Merge pull request #7731 from rgacogne/rec-fix-cache-cleaning
```

After:
```
20:45Z <PowerGit> [pdns] rgacogne pushed 2 commits to branch master: https://github.com/PowerDNS/pdns/compare/6f47ac4f8c97...ce7fdf89dcbf
20:45Z <PowerGit>  • rgacogne (6b0d90ea): rec: Fix the cache cleaning code being only run once for workers
20:45Z <PowerGit>  • rgacogne (ce7fdf89): Merge pull request #7731 from rgacogne/rec-fix-cache-cleaning
```

Context:
```
$ git log --abbrev-commit | head -1
commit ce7fdf89d
```

When `git` shortens a hash, it takes a prefix; the bot, without this PR, takes a suffix. Both work, of course, as long as there are no collisions.

Before this PR, the bot takes a 7 digit suffix; with this PR, it takes an 8 digit prefix. For the repo I'm using the bot on, `git` uses a 9 digit prefix because it has so many objects. For other repositories, `git` will often take just 7. However, the bot does not have the luxury of figuring out the right thing to do (because GitHub does not expose repo size, and also does not appear to put a 'minimal' hash in the webhook event).