### PR TITLE
Add "server_pass" to example config

### DIFF
--- a/examples/irccat.json
+++ b/examples/irccat.json
@@ -25,6 +25,7 @@
     "tls_skip_verify": false,
     "nick": "irccat",
     "realname": "IRCCat",
+    "server_pass": "",
     "identify_pass": "",
     "sasl_login": "",
     "sasl_pass": "",


### PR DESCRIPTION
After talking with russ on IRC it seems like `server_pass` was not mentioned in the example config. 

https://github.com/irccloud/irccat/blob/b9a691bc70b7dd3d92d88fa885ce8e13bc1e795d/irc.go#L32

This commit adds it to the example config.