### PR TITLE
Update link to Docker Hub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ release](https://github.com/irccloud/irccat/releases) from Github, put
 the [example config](examples/irccat.json)
 in `/etc/irccat.json` or the local directory and customise it, and run!
 
-A Docker container is also [provided on Docker Hub](https://hub.docker.com/repository/docker/irccloud/irccat).
+A Docker container is also [provided on Docker Hub](https://hub.docker.com/r/irccloud/irccat).
 
 ## TCP → IRC
 


### PR DESCRIPTION
Link was not the public one (at least asks me to login I guess to manage it).
The link in this commit is a public one.