### PR TITLE
Don't trim Git branches/tags with slashes down to the first component

### DIFF
--- a/httplistener/generic_test.go
+++ b/httplistener/generic_test.go
@@ -196,7 +196,7 @@ func testMultipartBase64(t *testing.T) {
 	}
 }
 
-func TestAll(t *testing.T) {
+func TestGeneric(t *testing.T) {
 	writer, err := loggo.RemoveWriter("default")
 	if err != nil {
 		t.Error(err)

--- a/httplistener/templates.go
+++ b/httplistener/templates.go
@@ -24,8 +24,9 @@ var defaultTemplates = map[string]string{
 }
 
 func refName(ref string) string {
+	// Trim leading 'refs/heads/', 'refs/tags/' etc.
 	parts := strings.Split(ref, "/")
-	return parts[2]
+	return strings.Join(parts[2:], "/")
 }
 
 func refType(ref string) string {

--- a/httplistener/templates_test.go
+++ b/httplistener/templates_test.go
@@ -1,0 +1,16 @@
+package httplistener
+
+import "testing"
+
+func TestTemplates(t *testing.T) {
+	test_refName(t, "refs/heads/main", "main")
+	test_refName(t, "refs/tags/v1.2.3", "v1.2.3")
+	test_refName(t, "refs/heads/feature/123-abc", "feature/123-abc")
+}
+
+func test_refName(t *testing.T, ref string, expected string) {
+	got := refName(ref)
+	if got != expected {
+		t.Fatalf("Expected ref %q to be prettified to %q, got %q", ref, expected, got)
+	}
+}


### PR DESCRIPTION
The test cases might be excessive here, but they helped me check this actually works.