### PR TITLE
Fix nil pointer dereference when TCP listener is configured

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,13 @@ func main() {
 	signal.Notify(irccat.signals, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go irccat.signalHandler()
 
+	err = irccat.connectIRC(*debug)
+
+	if err != nil {
+		log.Criticalf("Error connecting to IRC server: %s", err)
+		return
+	}
+
 	if viper.IsSet("tcp.listen") {
 		irccat.tcp, err = tcplistener.New()
 		if err != nil {
@@ -77,13 +84,6 @@ func main() {
 			return
 		}
 		irccat.tcp.Run(irccat.irc)
-	}
-
-	err = irccat.connectIRC(*debug)
-
-	if err != nil {
-		log.Criticalf("Error connecting to IRC server: %s", err)
-		return
 	}
 
 	if viper.IsSet("http") {


### PR DESCRIPTION
After 60526f60a842dac2a925c1bcf664ad65b6f0f968 (#31),
`irccat.tcp.Run(irccat.irc)` is called (if the config calls for it)
before, rather than after, `irccat.connectIRC()`, which changes
`irccat.irc` away from a nil pointer in the first place.  This pointer
is copied into the `irc` field of a TCPListener `l` by
`irccat.tcp.Run()`.

A panic won't actually happen until the TCP listener handles its first
message, if it ever comes, and in doing so passes the nil pointer
further down to `dispatcher.Send(l.irc, ...)`.

To fix, bring the call to `irccat.connectIRC()` forward again, to before
any listener setup is done at all.  This probably makes sense
stylistically too.