### PR TITLE
Support nick prefixes '~' and '&'

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -35,7 +35,7 @@ func (i *IRCCat) handleNames(e *irc.Event) {
 		nicks := strings.Split(e.Arguments[3], " ")
 		for _, nick := range nicks {
 			// TODO: this is probably not an optimal way of trimming the mode characters.
-			nick = strings.TrimLeft(nick, "@%+")
+			nick = strings.TrimLeft(nick, "~&@%+")
 			i.auth_users[nick] = true
 		}
 	}


### PR DESCRIPTION
In (at least) [ngIRCd](https://github.com/ngircd/ngircd/blob/512af135d06e7dad93f51eae51b3979e1d4005cc/doc/Modes.txt#L70), '~" and '&' are the prefix characters for channel "owner" and "admin", respectively.  Without this patch, channel owners aren't recognized as authorized if they joined before irccat started.