### PR TITLE
Add an option for muting GitHub merge queue internal operations

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -10,10 +10,11 @@ import (
 // Take a string, parse out the recipients, and send to IRC.
 //
 // eg:
-//  hello world                 [goes to default channel]
-//  #test hello world           [goes to #test, if joined]
-//  #test,@alice hello world    [goes to #test and alice]
-//  #* hello world              [goes to all channels bot is in]
+//
+//	hello world                 [goes to default channel]
+//	#test hello world           [goes to #test, if joined]
+//	#test,@alice hello world    [goes to #test and alice]
+//	#* hello world              [goes to all channels bot is in]
 func Send(irc *irc.Connection, msg string, log loggo.Logger, origin string) {
 	channels := viper.GetStringSlice("irc.channels")
 

--- a/examples/irccat.json
+++ b/examples/irccat.json
@@ -14,12 +14,13 @@
       },
       "grafana": "#channel",
       "github": {
-	"secret": "my_secret",
-	"default_channel": "#irccat-dev",
-	"repositories": {
-	    "irccat": "#irccat-dev"
-	}
-       }
+        "secret": "my_secret",
+        "default_channel": "#irccat-dev",
+        "mute_merge_queues": true,
+        "repositories": {
+          "irccat": "#irccat-dev"
+        }
+      }
     }
   },
   "irc": {
@@ -35,8 +36,12 @@
     "sasl_external": false,
     "sasl_login": "",
     "sasl_pass": "",
-    "channels": ["#channel"],
-    "keys": {"#channel": "join_key"}
+    "channels": [
+      "#channel"
+    ],
+    "keys": {
+      "#channel": "join_key"
+    }
   },
   "commands": {
     "auth_channel": "#channel",

--- a/httplistener/generic_test.go
+++ b/httplistener/generic_test.go
@@ -7,44 +7,43 @@
 //
 // mismatch
 //
-//  $ echo "%BOLDhw" | curl -d @- http://localhost/send
-//  400 Bad Request
+//	$ echo "%BOLDhw" | curl -d @- http://localhost/send
+//	400 Bad Request
 //
 // urlencoded
 //
-//  $ echo "%BOLDhw" | curl --data-urlencode  @- http://localhost/send
-//  200 OK
+//	$ echo "%BOLDhw" | curl --data-urlencode  @- http://localhost/send
+//	200 OK
 //
 // urlencoded non-printable
 //
-//  $ printf "\x02hw" | curl --data-urlencode  @- http://localhost/send
-//  200 OK
+//	$ printf "\x02hw" | curl --data-urlencode  @- http://localhost/send
+//	200 OK
 //
 // octetstream
 //
-//  $ echo "%BOLDhw" | curl --data-binary @- \
-//    -H 'Content-Type: application/octet-stream' http://localhost/send
-//  200 OK
+//	$ echo "%BOLDhw" | curl --data-binary @- \
+//	  -H 'Content-Type: application/octet-stream' http://localhost/send
+//	200 OK
 //
 // multipart quoted-printable
 //
-//  $ echo '%BOLDhw' | curl -F 'foo=@-;encoder=quoted-printable' \
-//    http://localhost/send
-//  200 OK
+//	$ echo '%BOLDhw' | curl -F 'foo=@-;encoder=quoted-printable' \
+//	  http://localhost/send
+//	200 OK
 //
 // multipart 8bit
 //
-//  $ echo '%BOLDhw' | curl -F 'foo=@-;encoder=8bit' http://localhost/send
-//  200 OK
+//	$ echo '%BOLDhw' | curl -F 'foo=@-;encoder=8bit' http://localhost/send
+//	200 OK
 //
 // multipart base64
 //
-//  $ echo '%BOLDhw' | curl -F 'foo=@-;encoder=base64' http://localhost/send
-//  200 OK
+//	$ echo '%BOLDhw' | curl -F 'foo=@-;encoder=base64' http://localhost/send
+//	200 OK
 //
 // The gist is that when strict mode is active, popular encodings will work
 // while mismatches won't, even though they may still appear to at times.
-//
 package httplistener
 
 import (
@@ -72,7 +71,7 @@ func genericTestStartHTTPServer(t *testing.T, endpoint string) {
 
 	http.HandleFunc(endpoint, hl.genericHandler)
 	go hl.http.ListenAndServe()
-	t.Cleanup(func() {hl.http.Shutdown(context.Background());})
+	t.Cleanup(func() { hl.http.Shutdown(context.Background()) })
 	time.Sleep(time.Millisecond)
 }
 
@@ -86,7 +85,7 @@ func genericTestSendOutput(message []byte) ([]byte, error) {
 		return nil, err
 	}
 	b := make([]byte, 1024)
-	_ , err = io.ReadAtLeast(conn, b, 24)
+	_, err = io.ReadAtLeast(conn, b, 24)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +98,7 @@ func runGeneric(t *testing.T, reqFileName string) (string, string) {
 	genericSender = func(_ *irc.Connection, m string, _ loggo.Logger, _ string) {
 		message = m
 	}
-	t.Cleanup(func(){genericSender = origSender})
+	t.Cleanup(func() { genericSender = origSender })
 
 	src, err := os.ReadFile(path.Join("testdata", reqFileName))
 	if err != nil {
@@ -201,7 +200,7 @@ func TestGeneric(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	t.Cleanup(func() {loggo.DefaultContext().AddWriter("default", writer)})
+	t.Cleanup(func() { loggo.DefaultContext().AddWriter("default", writer) })
 	genericTestStartHTTPServer(t, "/send")
 
 	t.Run("Baseline", testGenericBaseline)

--- a/httplistener/github.go
+++ b/httplistener/github.go
@@ -16,6 +16,10 @@ func interestingIssueAction(action string) bool {
 	return false
 }
 
+func isMergeQueueBranch(ref string) bool {
+	return strings.HasPrefix(ref, "gh-readonly-queue/") || strings.HasPrefix(ref, "refs/heads/gh-readonly-queue/")
+}
+
 func (hl *HTTPListener) githubHandler(w http.ResponseWriter, request *http.Request) {
 	if request.Method != "POST" {
 		http.NotFound(w, request)
@@ -57,6 +61,9 @@ func (hl *HTTPListener) githubHandler(w http.ResponseWriter, request *http.Reque
 		}
 	case github.PushPayload:
 		pl := payload.(github.PushPayload)
+		if viper.GetBool("http.listeners.github.mute_merge_queues") && isMergeQueueBranch(pl.Ref) {
+			return
+		}
 		send = true
 		msgs, err = hl.renderTemplate("github.push", payload)
 		repo = pl.Repository.Name
@@ -84,6 +91,9 @@ func (hl *HTTPListener) githubHandler(w http.ResponseWriter, request *http.Reque
 	case github.CheckSuitePayload:
 		pl := payload.(github.CheckSuitePayload)
 		if pl.CheckSuite.Status == "completed" && pl.CheckSuite.Conclusion == "failure" {
+			if viper.GetBool("http.listeners.github.mute_merge_queues") && isMergeQueueBranch(pl.CheckSuite.HeadBranch) {
+				return
+			}
 			send = true
 			msgs, err = hl.renderTemplate("github.checksuite", payload)
 			repo = pl.Repository.Name

--- a/httplistener/github_test.go
+++ b/httplistener/github_test.go
@@ -1,0 +1,24 @@
+package httplistener
+
+import (
+	"testing"
+)
+
+func TestIsMergeQueueBranch(t *testing.T) {
+	tests := []struct {
+		ref      string
+		expected bool
+	}{
+		{"refs/heads/master", false},
+		{"refs/heads/gh-readonly-queue/master/pr-1", true},
+		{"gh-readonly-queue/master/pr-1", true},
+		{"main", false},
+		{"refs/tags/v1.0.0", false},
+	}
+
+	for _, tc := range tests {
+		if got := isMergeQueueBranch(tc.ref); got != tc.expected {
+			t.Errorf("isMergeQueueBranch(%q) = %v; want %v", tc.ref, got, tc.expected)
+		}
+	}
+}


### PR DESCRIPTION
When using [GitHub merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue), GitHub still sends `push` webhooks for the internal branches that are used, which can be quite spammy.

Add an option for dropping these events on the floor, because they're spammy and not useful.

Note that this also silences check suite results - this might not be desired, because it can be useful to know when the merge queue's check has failed since this will probably block the PR from merging.